### PR TITLE
[DPE-1510] Add minor fixes to validation and dataset name correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Sample workflow
 Run clinical processing
 ```
 python3 clinical.py 
+    --dataset Riaz
     --input_df_synid syn66314245 \
     --cli_to_cbio_mapping_synid syn66276162 
     --cli_to_oncotree_mapping_synid syn66313842 \

--- a/src/iatlascbioportalexport/clinical.py
+++ b/src/iatlascbioportalexport/clinical.py
@@ -535,7 +535,7 @@ def convert_days_to_months(input_df: pd.DataFrame, col: str, **kwargs) -> pd.Dat
         return input_df
 
 
-def get_all_non_na_columns(input_df: pd.DataFrame) -> List[str]:
+def get_all_non_na_columns(input_df: pd.DataFrame, **kwargs) -> List[str]:
     """Gets all the columns in input data without all (100%) NAs
     Args:
         input_df (pd.DataFrame): input data
@@ -544,6 +544,10 @@ def get_all_non_na_columns(input_df: pd.DataFrame) -> List[str]:
         List[str]: Returns a list of column names in df where there is at least
         one value (subsets out columns with all NAs)
     """
+    logger = kwargs.get("logger", logging.getLogger(__name__))
+    logger.info(
+        f"These columns with all NAs will be removed: {input_df.columns[input_df.isna().all()].tolist()}"
+    )
     return input_df.columns[~input_df.isna().all()].tolist()
 
 

--- a/src/iatlascbioportalexport/clinical.py
+++ b/src/iatlascbioportalexport/clinical.py
@@ -24,7 +24,7 @@ IATLAS_DATASETS = [
     "HTAN_OHSU",
     "HugoLo_IPRES_2016",
     "IMmotion150",
-    "IMVigor210",
+    "IMvigor210",
     "Kim_NatMed_2018",
     "Liu_NatMed_2019",
     "Melero_GBM_2019",

--- a/src/iatlascbioportalexport/maf.py
+++ b/src/iatlascbioportalexport/maf.py
@@ -11,6 +11,7 @@ import utils
 
 syn = utils.synapse_login()
 
+
 def read_and_merge_maf_files(input_folder_synid: str) -> pd.DataFrame:
     """Read in and merge MAF files from a specified folder
 
@@ -77,7 +78,7 @@ def run_genome_nexus(
 ) -> None:
     """Runs genome nexus annotator on each of the split maf chunks. Logging
         is saved for each chunk.
-        
+
         This will parallelize the workflow if n_workers is defined or > 1,
         otherwise it will run genome nexus on each of the chunk(s) serially
 
@@ -271,6 +272,40 @@ def validate_that_allele_freq_are_not_na(
             )
 
 
+def summarize_error_report(
+    dataset_name: str, datahub_tools_path: str, **kwargs
+) -> pd.DataFrame:
+    """Summarizes the error report based on FAILURE_REASON
+    and VARIANT_CLASSIFICATION for quick review
+
+    Args:
+        dataset_name (str): name of dataset
+        datahub_tools_path (str):  Path to the datahub tools repo
+
+    Returns:
+        pd.DataFrame: summary table of the failed error reports
+    """
+    logger = kwargs.get("logger", logging.getLogger(__name__))
+    dataset_dir = utils.get_local_dataset_output_folder_path(
+        dataset_name=dataset_name, datahub_tools_path=datahub_tools_path
+    )
+    df = pd.read_csv(
+        os.path.join(dataset_dir, "data_mutations_error_report.txt"), sep="\t"
+    )
+    df_filtered = df[df["CHR"] != "chrM"]  # ignore chrM errors
+
+    summary = (
+        df_filtered.groupby(["FAILURE_REASON", "VARIANT_CLASSIFICATION"])
+        .size()
+        .reset_index(name="N")
+    )
+
+    logger.info("Grouped error summary (excluding chrM):")
+    logger.info("\n" + summary.to_string(index=False))
+
+    return summary
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -306,7 +341,7 @@ def main():
         default=False,
         help="Whether to clear local directory of files or not",
     )
-    
+
     args = parser.parse_args()
     if args.clear_workspace:
         utils.clear_workspace(dir_path=f"{args.datahub_tools_path}/add-clinical-header")
@@ -315,7 +350,7 @@ def main():
         dataset_name=args.dataset,
         datahub_tools_path=args.datahub_tools_path,
         log_file_name="iatlas_maf_validation_log.txt",
-        flagger=dataset_flagger
+        flagger=dataset_flagger,
     )
     maf_df = read_and_merge_maf_files(input_folder_synid=args.input_folder_synid)
     n_maf_chunks = split_into_chunks(
@@ -341,6 +376,11 @@ def main():
     validate_that_allele_freq_are_not_na(mafs["annotated_maf"], logger=dataset_logger)
     generate_meta_files(
         dataset_name=args.dataset, datahub_tools_path=args.datahub_tools_path
+    )
+    summarize_error_report(
+        dataset_name=args.dataset,
+        datahub_tools_path=args.datahub_tools_path,
+        logger=dataset_logger,
     )
     if dataset_flagger.had_error:
         dataset_logger.error("FAILED: Validation of study failed")

--- a/src/iatlascbioportalexport/maf.py
+++ b/src/iatlascbioportalexport/maf.py
@@ -231,16 +231,18 @@ def validate_export_files(
         output_df (pd.DataFrame): output annotated maf data
     """
     logger = kwargs.get("logger", logging.getLogger(__name__))
-    if len(input_df) != len(output_df):
+    # exclude chrM variants when counting
+    input_df_excl_chrM = input_df[input_df.Chromosome != "chrM"]
+    if len(input_df_excl_chrM) != len(output_df):
         logger.error(
-            f"Output rows {len(output_df)} are not equal to input rows {len(input_df)}."
+            f"Output rows {len(output_df)} are not equal to input rows {len(input_df_excl_chrM)}."
         )
     # no dups
     if len(output_df[output_df.duplicated()]) > 0:
         logger.error("There are duplicates in the output.")
     # check that the Tumor_Sample_Barcode exists in original maf
     if set(list(output_df.Tumor_Sample_Barcode.unique())) != set(
-        list(input_df.Tumor_Sample_Barcode.unique())
+        list(input_df_excl_chrM.Tumor_Sample_Barcode.unique())
     ):
         logger.error(
             "The Tumor_Sample_Barcode values are not equal in the output compared to input."

--- a/tests/test_maf.py
+++ b/tests/test_maf.py
@@ -218,3 +218,52 @@ def test_validate_that_allele_freq_are_not_na_does_expected_logging(
         )
     else:
         assert len(caplog.records) == 0
+
+
+
+def test_summarize_error_report(tmp_path):
+    dataset_dir = tmp_path / "dataset"
+    dataset_dir.mkdir()
+
+    # mock data_mutations_error_report.txt
+    input_file = dataset_dir / "data_mutations_error_report.txt"
+    df_input = pd.DataFrame(
+        {
+            "CHR": ["chr1", "chrM", "chr2", "chr1"],
+            "FAILURE_REASON": ["ReasonA", "ReasonA", "ReasonB", "ReasonA"],
+            "VARIANT_CLASSIFICATION": [
+                "Class1",
+                "Class1",
+                "Class2",
+                "Class1",
+            ],
+        }
+    )
+    df_input.to_csv(input_file, sep="\t", index=False)
+    mock_logger = mock.MagicMock()
+
+    summary = maf_to_cbio.summarize_error_report(
+        dataset_name="dummy",
+        datahub_tools_path="/unused",
+        logger=mock_logger,
+    )
+
+    # Assert expected output
+    # chrM row is ignored
+    # Remaining rows:
+    # ReasonA / Class1 → 2 rows (chr1, chr1)
+    # ReasonB / Class2 → 1 row (chr2)
+    expected = pd.DataFrame(
+        {
+            "FAILURE_REASON": ["ReasonA", "ReasonB"],
+            "VARIANT_CLASSIFICATION": ["Class1", "Class2"],
+            "N": [2, 1],
+        }
+    )
+
+    pd.testing.assert_frame_equal(summary.sort_values(by=["FAILURE_REASON"]),
+                                  expected.sort_values(by=["FAILURE_REASON"]),
+                                  check_like=True)
+
+
+    mock_logger.info.assert_any_call("Grouped error summary (excluding chrM):")

--- a/tests/test_maf.py
+++ b/tests/test_maf.py
@@ -23,9 +23,10 @@ def test_that_read_and_merge_maf_files_returns_expected_when_has_maf_files(syn_m
 
     syn_mock.get.side_effect = lambda x: mock.Mock(path=f"/fake/path/{x}.maf")
 
-    with mock.patch.object(maf_to_cbio, "syn", syn_mock), mock.patch.object(
-        maf_to_cbio.pd, "read_csv"
-    ) as mock_read_csv:
+    with (
+        mock.patch.object(maf_to_cbio, "syn", syn_mock),
+        mock.patch.object(maf_to_cbio.pd, "read_csv") as mock_read_csv,
+    ):
 
         mock_read_csv.side_effect = [
             pd.DataFrame({"col": [1]}),
@@ -100,20 +101,40 @@ def test_that_postprocessing_removes_chrM_variants():
     [
         # Case 1: Rows are unequal -> Error
         (
-            pd.DataFrame({"Tumor_Sample_Barcode": [10, 20, 20]}),
-            pd.DataFrame({"Tumor_Sample_Barcode": [10, 20]}),
+            pd.DataFrame(
+                {"Tumor_Sample_Barcode": [10, 20, 20], "Chromosome": ["1", "X", "Y"]}
+            ),
+            pd.DataFrame({"Tumor_Sample_Barcode": [10, 20], "Chromosome": ["X", "Y"]}),
             "Output rows 2 are not equal to input rows 3.",
         ),
         # Case 2: output has duplicates -> Error
         (
-            pd.DataFrame({"Tumor_Sample_Barcode": [10, 10, 30]}),
-            pd.DataFrame({"Tumor_Sample_Barcode": [10, 10, 30]}),
+            pd.DataFrame(
+                {"Tumor_Sample_Barcode": [10, 10, 30], "Chromosome": ["1", "X", "Y"]}
+            ),
+            pd.DataFrame(
+                {"Tumor_Sample_Barcode": [10, 10, 30], "Chromosome": ["1", "X", "Y"]}
+            ),
             "There are duplicates in the output.",
         ),
         # Case 3: tumor_sample_barcode vals in output not input -> Error
         (
-            pd.DataFrame({"Tumor_Sample_Barcode": [10, 23, 30]}),
-            pd.DataFrame({"Tumor_Sample_Barcode": [10, 20, 30]}),
+            pd.DataFrame(
+                {"Tumor_Sample_Barcode": [10, 23, 30], "Chromosome": ["1", "X", "Y"]}
+            ),
+            pd.DataFrame(
+                {"Tumor_Sample_Barcode": [10, 20, 30], "Chromosome": ["1", "X", "Y"]}
+            ),
+            "The Tumor_Sample_Barcode values are not equal in the output compared to input.",
+        ),
+        # Case 4: has chrM variants and after removing, input rows and output rows are unequal
+        (
+            pd.DataFrame(
+                {"Tumor_Sample_Barcode": [10, 23, 30], "Chromosome": ["chrM", "X", "Y"]}
+            ),
+            pd.DataFrame(
+                {"Tumor_Sample_Barcode": [10, 20, 30], "Chromosome": ["chrM", "X", "Y"]}
+            ),
             "The Tumor_Sample_Barcode values are not equal in the output compared to input.",
         ),
     ],
@@ -131,7 +152,7 @@ def test_that_validate_export_files_does_expected_error_logging(
 def test_that_validate_export_files_has_no_logging_when_valid(caplog):
     # Rows are equal, no duplicates, and tumor_sample_barcode matches -> No error
     input = pd.DataFrame(
-        {"Tumor_Sample_Barcode": [10, 20, 30], "Chromosome": ["M", "2", "1"]}
+        {"Tumor_Sample_Barcode": [5, 10, 20, 30], "Chromosome": ["chrM", "M", "2", "1"]}
     )
     output = pd.DataFrame(
         {"Tumor_Sample_Barcode": [10, 20, 30], "Chromosome": ["M", "2", "1"]}

--- a/tests/test_maf.py
+++ b/tests/test_maf.py
@@ -23,10 +23,11 @@ def test_that_read_and_merge_maf_files_returns_expected_when_has_maf_files(syn_m
 
     syn_mock.get.side_effect = lambda x: mock.Mock(path=f"/fake/path/{x}.maf")
 
-    with (
-        mock.patch.object(maf_to_cbio, "syn", syn_mock),
-        mock.patch.object(maf_to_cbio.pd, "read_csv") as mock_read_csv,
-    ):
+    with mock.patch.object(
+        maf_to_cbio, "syn", syn_mock
+    ), mock.patch.object(
+        maf_to_cbio.pd, "read_csv"
+    ) as mock_read_csv:
 
         mock_read_csv.side_effect = [
             pd.DataFrame({"col": [1]}),
@@ -130,10 +131,10 @@ def test_that_postprocessing_removes_chrM_variants():
         # Case 4: has chrM variants and after removing, input rows and output rows are unequal
         (
             pd.DataFrame(
-                {"Tumor_Sample_Barcode": [10, 23, 30], "Chromosome": ["chrM", "X", "Y"]}
+                {"Tumor_Sample_Barcode": [23, 30], "Chromosome": ["X", "Y"]}
             ),
             pd.DataFrame(
-                {"Tumor_Sample_Barcode": [10, 20, 30], "Chromosome": ["chrM", "X", "Y"]}
+                {"Tumor_Sample_Barcode": [20, 30], "Chromosome": ["X", "Y"]}
             ),
             "The Tumor_Sample_Barcode values are not equal in the output compared to input.",
         ),


### PR DESCRIPTION
# **Problem:**
- IMVigor210's dataset name changed to IMvigor210
- Some changes needed to improve and automate validation (previously done manually)

# **Solution:**
- Update to IMvigor210 everywhere

Validation changes:
- Add consistent validation by removing `chrM` variants in maf validation as well
- Create summary table for failed annotations in logs for ease of review
- Create logging to output all NA clinical columns being removed for ease of review

# **Testing:**
- Unit tests
- Tested on IMVigor210